### PR TITLE
Try to make updating the version number easier

### DIFF
--- a/org.feichtmeier.Musicpod.appdata.xml
+++ b/org.feichtmeier.Musicpod.appdata.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.feichtmeier.Musicpod</id>
+  
+  <name>musicpod</name>
+  <summary>Music, podcast and internet radio player</summary>
+  
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <url type="homepage">https://github.com/ubuntu-flutter-community/musicpod</url>
+  
+  <description>
+    <p>
+      Play local audio files, browse podcasts online or listen to internet radio stations.
+    </p>
+  </description>
+<developer id="org.feichtmeier">
+  <name>Frederik Feichtmeier</name>
+</developer>
+
+  <screenshots>
+    <screenshot type="default">
+      <caption>Album - light</caption>
+      <image type="source">https://raw.githubusercontent.com/ubuntu-flutter-community/musicpod/main/.github/album_light.png</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Album - dark</caption>
+      <image type="source">https://raw.githubusercontent.com/ubuntu-flutter-community/musicpod/main/.github/album_dark.png</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Fullscreen - light</caption>
+      <image type="source">https://raw.githubusercontent.com/ubuntu-flutter-community/musicpod/main/.github/full_window_light.png</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Fullscreen - dark</caption>
+      <image type="source">https://raw.githubusercontent.com/ubuntu-flutter-community/musicpod/main/.github/full_window_dark.png</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Podcast overview - light</caption>
+      <image type="source">https://raw.githubusercontent.com/ubuntu-flutter-community/musicpod/main/.github/wide_window_light.png</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Podcast overview - dark</caption>
+      <image type="source">https://raw.githubusercontent.com/ubuntu-flutter-community/musicpod/main/.github/wide_window_dark.png</image>
+    </screenshot>
+  </screenshots>
+  
+  <releases>
+    <release date="2024-08-01" version="1.5.2"/>    
+    <release date="2024-05-06" version="0.3.7"/>
+    <release date="2022-03-12" version="0.1.1"/>
+  </releases>
+
+  <content_rating type="oars-1.1" />
+
+  <launchable type="desktop-id">org.feichtmeier.Musicpod.desktop</launchable>
+</component>

--- a/org.feichtmeier.Musicpod.json
+++ b/org.feichtmeier.Musicpod.json
@@ -203,8 +203,7 @@
                     "sources": [
                         {
                             "type": "file",
-                            "sha256": "671aa0c690b6eedd4f3939f63ed6f9f0f9bc1032ef57001b491d1df34a057ae0",
-                            "url": "https://raw.githubusercontent.com/ubuntu-flutter-community/musicpod/1b4751b0e0f7d9c1ddb21f3abc2bdc1745cc7df2/flatpak/org.feichtmeier.Musicpod.appdata.xml"
+                            "path": "org.feichtmeier.Musicpod.appdata.xml"
                         },
                         {
                             "type": "file",

--- a/org.feichtmeier.Musicpod.json
+++ b/org.feichtmeier.Musicpod.json
@@ -203,8 +203,8 @@
                     "sources": [
                         {
                             "type": "file",
-                            "sha256": "ea781de7204f51472e8d34724e86bffb9b36f00e9774adacc0d4ef06d0ac98ea",
-                            "url": "https://raw.githubusercontent.com/ubuntu-flutter-community/musicpod/9fe76f9400024f3094b0018e7e5f44073731b58e/flatpak/org.feichtmeier.Musicpod.appdata.xml"
+                            "sha256": "671aa0c690b6eedd4f3939f63ed6f9f0f9bc1032ef57001b491d1df34a057ae0",
+                            "url": "https://raw.githubusercontent.com/ubuntu-flutter-community/musicpod/1b4751b0e0f7d9c1ddb21f3abc2bdc1745cc7df2/flatpak/org.feichtmeier.Musicpod.appdata.xml"
                         },
                         {
                             "type": "file",


### PR DESCRIPTION
This should allow me to update the version number easier. It moves the flatpak app data file from the musicpod repo (I'll delete it later) to here, and basically halves the work I'd need to do.